### PR TITLE
Add simple codec for letters and digits with tests

### DIFF
--- a/PythonTest_18082025/Day2/README.md
+++ b/PythonTest_18082025/Day2/README.md
@@ -1,0 +1,8 @@
+# Day2 codec26
+
+Демо и тесты:
+
+```bash
+python codec26.py
+pytest -q
+```

--- a/PythonTest_18082025/Day2/codec26.py
+++ b/PythonTest_18082025/Day2/codec26.py
@@ -1,0 +1,73 @@
+"""Простой шифр: каждые две цифры кодируют символ.
+
+Пример:
+>>> decode("070411111426152419071413")
+'hello python'
+>>> encode("hello python")
+'070411111426152419071413'
+"""
+
+# алфавит и пробел
+ALPHABET = "abcdefghijklmnopqrstuvwxyz"
+SPACE = " "
+
+# разрешённые символы для текста и числа
+ALLOW_TXT = set(ALPHABET + SPACE)
+DIGITS = set("0123456789")
+
+def decode(num: str) -> str:
+    """Превращаем цифры в текст.
+
+    >>> decode("00")
+    'a'
+    """
+    # проверяем, что в строке только цифры
+    bad = set(num) - DIGITS
+    if bad:
+        raise ValueError(f"недопустимые символы: {''.join(sorted(bad))!r}")
+    # длина должна быть чётной
+    if len(num) % 2 == 1:
+        raise ValueError("нечётное число цифр")
+
+    result = []
+    # читаем по две цифры
+    for i in range(0, len(num), 2):
+        pair = num[i:i + 2]
+        if not pair:
+            continue
+        code = int(pair)
+        # 26 — это пробел
+        if code == 26:
+            result.append(SPACE)
+        elif 0 <= code <= 25:
+            result.append(ALPHABET[code])
+        else:
+            raise ValueError(f"неизвестный код: {pair}")
+    return "".join(result)
+
+def encode(text: str) -> str:
+    """Превращаем текст в цифры.
+
+    >>> encode("a")
+    '00'
+    """
+    text = text.lower()
+    # проверяем разрешённые символы через множество
+    bad = set(text) - ALLOW_TXT
+    if bad:
+        raise ValueError(f"недопустимые символы: {''.join(sorted(bad))!r}")
+
+    result = []
+    for ch in text:
+        if ch == SPACE:
+            result.append("26")
+        else:
+            # позиция буквы в алфавите даёт её код
+            idx = ALPHABET.index(ch)
+            result.append(f"{idx:02d}")
+    return "".join(result)
+
+if __name__ == "__main__":
+    # небольшое демо
+    print(decode("070411111426152419071413"))
+    print(encode("hello python"))

--- a/PythonTest_18082025/Day2/test_codec26.py
+++ b/PythonTest_18082025/Day2/test_codec26.py
@@ -1,0 +1,35 @@
+import pytest
+
+from codec26 import decode, encode
+
+def test_decode_example():
+    assert decode("070411111426152419071413") == "hello python"
+
+def test_encode_example():
+    assert encode("hello python") == "070411111426152419071413"
+
+def test_empty():
+    assert decode("") == ""
+    assert encode("") == ""
+
+def test_single_space():
+    assert decode("26") == " "
+    assert encode(" ") == "26"
+
+@pytest.mark.parametrize("text", ["a", "abc", "python is fun", "", "hello world"])
+def test_round_trip_text(text):
+    assert decode(encode(text)) == text
+
+@pytest.mark.parametrize("num", ["00", "2600", "0126", "070411111426152419071413", ""])
+def test_round_trip_num(num):
+    assert encode(decode(num)) == num
+
+@pytest.mark.parametrize("num", ["07a4", " 07", "001", "27", "99", "2700"])
+def test_decode_errors(num):
+    with pytest.raises(ValueError):
+        decode(num)
+
+@pytest.mark.parametrize("text", ["Hello!", "привет", "a_b", "a\nb", "a1b", "\t"])
+def test_encode_errors(text):
+    with pytest.raises(ValueError):
+        encode(text)


### PR DESCRIPTION
## Summary
- Implement `codec26` with `encode` and `decode` functions for mapping letters/spaces to two-digit codes
- Provide demo usage and instructions
- Add pytest suite covering valid cases and error handling

## Testing
- `python codec26.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a4d4ac02948323b5b5439c3a6cacdc