### PR TITLE
Fix relative imports for homework_04 main script

### DIFF
--- a/homework_04/main.py
+++ b/homework_04/main.py
@@ -16,8 +16,12 @@
 import asyncio
 from typing import List
 
-from . import jsonplaceholder_requests as jp_requests
-from .models import Base, Session, User, Post, engine
+try:
+    from . import jsonplaceholder_requests as jp_requests
+    from .models import Base, Session, User, Post, engine
+except ImportError:  # pragma: no cover - fallback for direct execution
+    import jsonplaceholder_requests as jp_requests
+    from models import Base, Session, User, Post, engine
 
 
 async def async_main() -> None:


### PR DESCRIPTION
## Summary
- allow `homework_04/main.py` to run directly or as module with fallback imports

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django', 'tasks', etc.)*
- `python homework_04/main.py` *(fails: ModuleNotFoundError: No module named 'aiohttp')*
- `python -m homework_04.main` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68b2ee54307083239540bd2d25951fa4