### PR TITLE
Add FastAPI notes app with Docker Compose

### DIFF
--- a/homework_05/Dockerfile
+++ b/homework_05/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+CMD ["gunicorn", "app.main:app", "-k", "uvicorn.workers.UvicornWorker", "--bind", "0.0.0.0:8000"]

--- a/homework_05/app/database.py
+++ b/homework_05/app/database.py
@@ -1,0 +1,19 @@
+import os
+from typing import AsyncGenerator
+
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+
+DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql+asyncpg://postgres:postgres@db:5432/notes",
+)
+
+engine = create_async_engine(DATABASE_URL, echo=True)
+SessionLocal = sessionmaker(bind=engine, class_=AsyncSession, expire_on_commit=False)
+Base = declarative_base()
+
+
+async def get_session() -> AsyncGenerator[AsyncSession, None]:
+    async with SessionLocal() as session:
+        yield session

--- a/homework_05/app/main.py
+++ b/homework_05/app/main.py
@@ -1,0 +1,53 @@
+from fastapi import Depends, FastAPI, Form, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select
+
+from .database import Base, engine, get_session
+from .models import Note
+from .schemas import NoteCreate, NoteOut
+
+app = FastAPI()
+templates = Jinja2Templates(directory="app/templates")
+
+
+@app.on_event("startup")
+async def on_startup() -> None:
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+
+@app.get("/api/notes", response_model=list[NoteOut])
+async def api_read_notes(session: AsyncSession = Depends(get_session)):
+    result = await session.execute(select(Note))
+    return result.scalars().all()
+
+
+@app.post("/api/notes", response_model=NoteOut)
+async def api_create_note(note: NoteCreate, session: AsyncSession = Depends(get_session)):
+    note_obj = Note(title=note.title, content=note.content)
+    session.add(note_obj)
+    await session.commit()
+    await session.refresh(note_obj)
+    return note_obj
+
+
+@app.get("/", response_class=HTMLResponse)
+async def read_notes_html(request: Request, session: AsyncSession = Depends(get_session)):
+    result = await session.execute(select(Note))
+    notes = result.scalars().all()
+    return templates.TemplateResponse("notes.html", {"request": request, "notes": notes})
+
+
+@app.post("/", response_class=HTMLResponse)
+async def create_note_html(
+    request: Request,
+    title: str = Form(...),
+    content: str = Form(None),
+    session: AsyncSession = Depends(get_session),
+):
+    note_obj = Note(title=title, content=content)
+    session.add(note_obj)
+    await session.commit()
+    return RedirectResponse(url="/", status_code=303)

--- a/homework_05/app/models.py
+++ b/homework_05/app/models.py
@@ -1,0 +1,11 @@
+from sqlalchemy import Column, Integer, String, Text
+
+from .database import Base
+
+
+class Note(Base):
+    __tablename__ = "notes"
+
+    id = Column(Integer, primary_key=True, index=True)
+    title = Column(String(100), nullable=False)
+    content = Column(Text)

--- a/homework_05/app/schemas.py
+++ b/homework_05/app/schemas.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel
+
+
+class NoteCreate(BaseModel):
+    title: str
+    content: str | None = None
+
+
+class NoteOut(NoteCreate):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/homework_05/app/templates/notes.html
+++ b/homework_05/app/templates/notes.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Notes</title>
+</head>
+<body>
+    <h1>Notes</h1>
+    <ul>
+        {% for note in notes %}
+        <li><strong>{{ note.title }}</strong>: {{ note.content }}</li>
+        {% else %}
+        <li>No notes yet</li>
+        {% endfor %}
+    </ul>
+
+    <h2>Add note</h2>
+    <form action="/" method="post">
+        <input type="text" name="title" placeholder="Title" required />
+        <input type="text" name="content" placeholder="Content" />
+        <button type="submit">Add</button>
+    </form>
+</body>
+</html>

--- a/homework_05/docker-compose.yml
+++ b/homework_05/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: notes
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      retries: 5
+
+  web:
+    build: .
+    depends_on:
+      - db
+    environment:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@db:5432/notes
+    expose:
+      - "8000"
+
+  nginx:
+    image: nginx:1.25-alpine
+    volumes:
+      - ./nginx.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "80:80"
+    depends_on:
+      - web
+
+volumes:
+  db_data:

--- a/homework_05/nginx.conf
+++ b/homework_05/nginx.conf
@@ -1,0 +1,11 @@
+server {
+    listen 80;
+
+    location / {
+        proxy_pass http://web:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/homework_05/requirements.txt
+++ b/homework_05/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+gunicorn
+SQLAlchemy>=1.4
+asyncpg
+jinja2


### PR DESCRIPTION
## Summary
- add FastAPI notes service with SQLAlchemy models and HTML UI
- containerize app with gunicorn and nginx reverse proxy
- provide docker-compose stack with PostgreSQL database

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68b2ee669afc8323903a33f5a69396b1